### PR TITLE
Fixed parameters to rounded style instead of format

### DIFF
--- a/src/Casinelli/Currency/Currency.php
+++ b/src/Casinelli/Currency/Currency.php
@@ -157,7 +157,7 @@ class Currency
 
     public function rounded($number, $decimal_place = 0, $currency = null)
     {
-        return $this->style($number, $currency, '%symbol%', false, '', null, $decimal_place);
+        return $this->style($number, $currency, $decimal_place);
     }
 
     public function getCurrencySymbol($right = false)


### PR DESCRIPTION
It appears this line used the style function incorrectly. I amended the parameters to work however I am unsure if it was supposed to be using the format function instead.
